### PR TITLE
Add health check to payment API

### DIFF
--- a/logic/payment.py
+++ b/logic/payment.py
@@ -25,4 +25,8 @@ def create_app(db_client: firestore.Client | None = None) -> Flask:
             )
         return jsonify({'status': 'ok'}), 200
 
+    @app.get('/healthz')
+    def healthz() -> tuple[str, int]:
+        return jsonify({'status': 'ok'}), 200
+
     return app

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -34,3 +34,12 @@ def test_webhook_updates_expiration():
     resp = client.post('/webhook/mp', json={'chat_id': '123'})
     assert resp.status_code == 200
     assert db.collection_obj.doc.data['exp_date'] > datetime.utcnow()
+
+
+def test_healthz_endpoint():
+    db = DummyDB()
+    app = payment.create_app(db)
+    client = app.test_client()
+    resp = client.get('/healthz')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint in `payment` module
- test health check endpoint

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ae3c5e7c832ab46362b57e709321