### PR TITLE
Add Telegram webhook integration

### DIFF
--- a/logic/payment.py
+++ b/logic/payment.py
@@ -3,8 +3,20 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify
 import os
+from telegram import Update
+from telegram.ext import Application, CommandHandler
 import json
 from google.cloud import firestore
+
+BOT_TOKEN = os.environ.get("TG_TOKEN", "")
+
+
+def build_bot() -> Application:
+    from bot.bot import start
+
+    app = Application.builder().token(BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    return app
 
 
 def create_app(db_client: firestore.Client | None = None) -> Flask:
@@ -27,6 +39,12 @@ def create_app(db_client: firestore.Client | None = None) -> Flask:
 
     @app.get('/healthz')
     def healthz() -> tuple[str, int]:
+        return jsonify({'status': 'ok'}), 200
+
+    @app.post(f"/bot/{BOT_TOKEN}")
+    def telegram_webhook() -> tuple[str, int]:
+        update = Update.de_json(request.get_json(force=True), build_bot().bot)
+        build_bot().process_update(update)
         return jsonify({'status': 'ok'}), 200
 
     return app

--- a/main.py
+++ b/main.py
@@ -1,8 +1,20 @@
 import argparse
+import os
 
-from bot.bot import run as run_bot
+from telegram import Update
+from telegram.ext import Application, CommandHandler
+
+from bot.bot import run as run_bot, start
 from logic.payment import create_app
 from logic.self_check import run as self_check_run
+
+BOT_TOKEN = os.environ.get("TG_TOKEN", "")
+
+
+def build_bot() -> Application:
+    app = Application.builder().token(BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    return app
 
 parser = argparse.ArgumentParser()
 parser.add_argument('command')


### PR DESCRIPTION
## Summary
- support Telegram bot token via TG_TOKEN
- build Telegram bot with start command
- create webhook endpoint under payment API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b1bb7264832a96f6e631fe075a78